### PR TITLE
feat!: support `process.env.FORCE_TTY`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,8 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - name: Install dependencies
         run: yarn install --frozen-lockfile --ignore-engines --ignore-scripts
+      - name: build
+        run: yarn build
       - name: Run unit tests
         run: yarn test
         env:

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1,5 +1,16 @@
-import { createColors } from './index'
+import {
+  createColors as originalCreateColors,
+  isSupported as originalIsSupported,
+} from './index'
 
-export * from './index'
+export { Colors, Formatter, getDefaultColors } from './index'
 
-export default createColors(false)
+export function isSupportted() {
+  return originalIsSupported()
+}
+
+export function createColors() {
+  return originalCreateColors()
+}
+
+export default originalCreateColors()

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -5,7 +5,7 @@ import {
 
 export { Colors, Formatter, getDefaultColors } from './index'
 
-export function isSupportted() {
+export function isSupported() {
   return originalIsSupported()
 }
 

--- a/src/node.ts
+++ b/src/node.ts
@@ -1,6 +1,19 @@
 import { isatty } from 'node:tty'
-import { createColors } from './index'
+import {
+  createColors as originalCreateColors,
+  isSupported as originalIsSupported,
+} from './index'
 
-export * from './index'
+export { Colors, Formatter, getDefaultColors } from './index'
 
-export default createColors(process.env.FORCE_TTY !== undefined || isatty(1))
+const isTTY = process.env.FORCE_TTY !== undefined || isatty(1)
+
+export function isSupportted() {
+  return originalIsSupported(isTTY)
+}
+
+export function createColors() {
+  return originalCreateColors(isTTY)
+}
+
+export default originalCreateColors(isTTY)

--- a/src/node.ts
+++ b/src/node.ts
@@ -3,4 +3,4 @@ import { createColors } from './index'
 
 export * from './index'
 
-export default createColors(isatty(1))
+export default createColors(process.env.FORCE_TTY !== undefined || isatty(1))

--- a/src/node.ts
+++ b/src/node.ts
@@ -8,7 +8,7 @@ export { Colors, Formatter, getDefaultColors } from './index'
 
 const isTTY = process.env.FORCE_TTY !== undefined || isatty(1)
 
-export function isSupportted() {
+export function isSupported() {
   return originalIsSupported(isTTY)
 }
 

--- a/tests/fixtures/child-process.mjs
+++ b/tests/fixtures/child-process.mjs
@@ -1,0 +1,5 @@
+import c from '../../dist/node.js'
+
+console.log(c.green('Green'))
+console.log(c.red('Red'))
+console.log({ FORCE_TTY: process.env.FORCE_TTY })


### PR DESCRIPTION
- Related to https://github.com/vitest-dev/vitest/issues/7042
- Adds support for by-passing `isatty()` checks when `process.env.FORCE_TTY` is set

It makes no sense that TTY check is used to resolve whether colors can be printed. In cases where we have multiple processes running and we are concatenating streams from child processes to main process (that's fully functioning TTY), colors should be enabled. 